### PR TITLE
Fix Typescript definition for CrontabTypes

### DIFF
--- a/lib/crontab_manager.d.ts
+++ b/lib/crontab_manager.d.ts
@@ -22,7 +22,7 @@ declare namespace CrontabTypes {
         onTick?: () => void
         onComplete?: () => void
         start?: boolean
-        timezone?: string
+        timeZone?: string
         context?: any
         runOnInit?: boolean
         utcOffset?: string


### PR DESCRIPTION
The `timezone` attribute is incorrectly capitalized in Typescript. It says `timezone` when it should be `timeZone`.